### PR TITLE
review feedback: With useCallbacks: true, persistEphemeralHyperId ran…

### DIFF
--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -87,8 +87,6 @@ export const novatiqIdSubmodule = {
     const url = syncUrl.url;
     const novatiqId = syncUrl.novatiqId;
 
-    this.persistEphemeralHyperId(novatiqId);
-
     // for testing
     const sharedStatus = (sharedId !== null && sharedId !== undefined && sharedId !== false) ? 'Found' : 'Not Found';
 
@@ -97,18 +95,20 @@ export const novatiqIdSubmodule = {
       res.sharedStatus = sharedStatus;
 
       return res;
-    } else {
-      this.sendSimpleSyncRequest(novatiqId, url);
-
-      return {
-        'id': novatiqId,
-        'sharedStatus': sharedStatus
-      };
     }
+
+    this.persistEphemeralHyperId(novatiqId);
+    this.sendSimpleSyncRequest(novatiqId, url);
+
+    return {
+      'id': novatiqId,
+      'sharedStatus': sharedStatus
+    };
   },
 
   sendAsyncSyncRequest(novatiqId, url) {
     logInfo('NOVATIQ Setting up ASYNC sync request');
+    const persistEphemeralHyperId = this.persistEphemeralHyperId.bind(this);
 
     const resp = function (callback) {
       logInfo('NOVATIQ *** Calling ASYNC sync request');
@@ -121,9 +121,11 @@ export const novatiqIdSubmodule = {
         logInfo('NOVATIQ *** ASYNC request returned ' + syncrc);
         if (syncrc === 200) {
           novatiqIdJson = { 'id': novatiqId, syncResponse: 1 };
+          persistEphemeralHyperId(novatiqId);
         } else {
           if (syncrc === 204) {
             novatiqIdJson = { 'id': novatiqId, syncResponse: 2 };
+            persistEphemeralHyperId(novatiqId);
           }
         }
         callback(novatiqIdJson);
@@ -150,9 +152,11 @@ export const novatiqIdSubmodule = {
    * @param {string} hyperId
    */
   persistEphemeralHyperId(hyperId) {
+    logInfo("Novatiq persistEphemeralHyperId")
     const ttlMs = NVQ_HID_TTL_MS;
     if (!novatiqStorage.cookiesAreEnabled()) {
       if (novatiqStorage.hasLocalStorage()) {
+        logInfo("Novatiq Writing HyperID in short lived local storage")
         novatiqStorage.setDataInLocalStorage(NVQ_HID_KEY, JSON.stringify({
           hyperId: hyperId,
           expiresAt: Date.now() + ttlMs
@@ -164,6 +168,7 @@ export const novatiqIdSubmodule = {
     if (novatiqStorage.hasLocalStorage()) {
       novatiqStorage.removeDataFromLocalStorage(NVQ_HID_KEY);
     }
+    logInfo("Novatiq Writing HyperID in short lived cookie")
     const expiry = new Date(Date.now() + ttlMs).toUTCString();
     novatiqStorage.setCookie(NVQ_HID_KEY, hyperId, expiry, 'Lax');
     logInfo('NOVATIQ ephemeral hyperId stored in cookie (' + (ttlMs / 1000) + 's TTL)');

--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -22,6 +22,9 @@ const MODULE_NAME = 'novatiq';
 const NVQ_HID_KEY = 'nvq_hid';
 const NVQ_HID_TTL_MS = 60 * 1000;
 
+/** @type {ReturnType<typeof setTimeout>|null} */
+let nvqHidLocalStorageExpiryTimer = null;
+
 export const novatiqStorage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
 /** @type {Submodule} */
@@ -152,15 +155,15 @@ export const novatiqIdSubmodule = {
    * @param {string} hyperId
    */
   persistEphemeralHyperId(hyperId) {
-    logInfo("Novatiq persistEphemeralHyperId")
     const ttlMs = NVQ_HID_TTL_MS;
     if (!novatiqStorage.cookiesAreEnabled()) {
       if (novatiqStorage.hasLocalStorage()) {
-        logInfo("Novatiq Writing HyperID in short lived local storage")
+        this.removeExpiredEphemeralHyperIdFromLocalStorage();
         novatiqStorage.setDataInLocalStorage(NVQ_HID_KEY, JSON.stringify({
           hyperId: hyperId,
           expiresAt: Date.now() + ttlMs
         }));
+        this.scheduleEphemeralHyperIdLocalStorageExpiry();
         logInfo('NOVATIQ ephemeral hyperId stored in localStorage (' + (ttlMs / 1000) + 's TTL, cookies unavailable)');
       }
       return;
@@ -168,10 +171,39 @@ export const novatiqIdSubmodule = {
     if (novatiqStorage.hasLocalStorage()) {
       novatiqStorage.removeDataFromLocalStorage(NVQ_HID_KEY);
     }
-    logInfo("Novatiq Writing HyperID in short lived cookie")
     const expiry = new Date(Date.now() + ttlMs).toUTCString();
     novatiqStorage.setCookie(NVQ_HID_KEY, hyperId, expiry, 'Lax');
     logInfo('NOVATIQ ephemeral hyperId stored in cookie (' + (ttlMs / 1000) + 's TTL)');
+  },
+
+  removeExpiredEphemeralHyperIdFromLocalStorage() {
+    if (!novatiqStorage.hasLocalStorage()) {
+      return;
+    }
+    const raw = novatiqStorage.getDataFromLocalStorage(NVQ_HID_KEY);
+    if (raw === null || raw === undefined || raw === '') {
+      return;
+    }
+    const payload = JSON.parse(raw);
+    if (typeof payload.expiresAt !== 'number' || payload.expiresAt <= Date.now()) {
+      novatiqStorage.removeDataFromLocalStorage(NVQ_HID_KEY);
+    }
+  },
+
+  scheduleEphemeralHyperIdLocalStorageExpiry() {
+    if (typeof window === 'undefined' || typeof window.setTimeout !== 'function') {
+      return;
+    }
+    if (nvqHidLocalStorageExpiryTimer !== null) {
+      window.clearTimeout(nvqHidLocalStorageExpiryTimer);
+    }
+    nvqHidLocalStorageExpiryTimer = window.setTimeout(function () {
+      if (novatiqStorage.hasLocalStorage()) {
+        novatiqStorage.removeDataFromLocalStorage(NVQ_HID_KEY);
+        logInfo('NOVATIQ ephemeral hyperId removed from localStorage after TTL');
+      }
+      nvqHidLocalStorageExpiryTimer = null;
+    }, NVQ_HID_TTL_MS);
   },
 
   getNovatiqId(urlParams) {

--- a/test/spec/modules/novatiqIdSystem_spec.js
+++ b/test/spec/modules/novatiqIdSystem_spec.js
@@ -1,4 +1,5 @@
 import { novatiqIdSubmodule, novatiqStorage } from 'modules/novatiqIdSystem.js';
+import { server } from 'test/mocks/xhr.js';
 
 describe('novatiqIdSystem', function () {
   const urlParams = {
@@ -133,6 +134,36 @@ describe('novatiqIdSystem', function () {
       const response = novatiqIdSubmodule.sendAsyncSyncRequest('testuuid', sync.url);
       expect(response.callback).should.not.be.empty;
     });
+
+    it('persists nvq_hid only after async sync accepts the id (200)', function (done) {
+      const persistStub = sinon.stub(novatiqIdSubmodule, 'persistEphemeralHyperId');
+      const config = { params: { sourceid: '123', useCallbacks: true } };
+      const response = novatiqIdSubmodule.getId(config);
+
+      expect(persistStub.called).to.equal(false);
+      response.callback(function (idObj) {
+        expect(idObj.id).to.have.length(40);
+        expect(persistStub.calledOnce).to.equal(true);
+        expect(persistStub.firstCall.args[0]).to.equal(idObj.id);
+        persistStub.restore();
+        done();
+      });
+      server.requests[0].respond(200);
+    });
+
+    it('does not persist nvq_hid when async sync does not accept the id', function (done) {
+      const persistStub = sinon.stub(novatiqIdSubmodule, 'persistEphemeralHyperId');
+      const config = { params: { sourceid: '123', useCallbacks: true } };
+      const response = novatiqIdSubmodule.getId(config);
+
+      response.callback(function (idObj) {
+        expect(idObj.id).to.be.undefined;
+        expect(persistStub.called).to.equal(false);
+        persistStub.restore();
+        done();
+      });
+      server.requests[0].respond(201);
+    });
   });
 
   describe('persistEphemeralHyperId', function () {
@@ -170,7 +201,7 @@ describe('novatiqIdSystem', function () {
   });
 
   describe('getId nvq_hid', function () {
-    it('persists ephemeral hyper id when sync runs', function () {
+    it('persists ephemeral hyper id when simple sync runs', function () {
       const stub = sinon.stub(novatiqIdSubmodule, 'persistEphemeralHyperId');
       const config = { params: { sourceid: '123' } };
       novatiqIdSubmodule.getId(config);

--- a/test/spec/modules/novatiqIdSystem_spec.js
+++ b/test/spec/modules/novatiqIdSystem_spec.js
@@ -188,15 +188,61 @@ describe('novatiqIdSystem', function () {
     it('stores nvq_hid in localStorage when cookies are not enabled', function () {
       const cookiesEnabled = sinon.stub(novatiqStorage, 'cookiesAreEnabled').returns(false);
       const hasLocalStorage = sinon.stub(novatiqStorage, 'hasLocalStorage').returns(true);
+      const getLs = sinon.stub(novatiqStorage, 'getDataFromLocalStorage').returns(null);
       const setLs = sinon.stub(novatiqStorage, 'setDataInLocalStorage');
+      const scheduleExpiry = sinon.stub(novatiqIdSubmodule, 'scheduleEphemeralHyperIdLocalStorageExpiry');
       novatiqIdSubmodule.persistEphemeralHyperId('hid-local');
+      expect(getLs.calledWith('nvq_hid')).to.equal(true);
       expect(setLs.firstCall.args[0]).to.equal('nvq_hid');
       const payload = JSON.parse(setLs.firstCall.args[1]);
       expect(payload.hyperId).to.equal('hid-local');
       expect(payload.expiresAt).to.be.closeTo(Date.now() + 60000, 3000);
+      expect(scheduleExpiry.calledOnce).to.equal(true);
       cookiesEnabled.restore();
       hasLocalStorage.restore();
+      getLs.restore();
       setLs.restore();
+      scheduleExpiry.restore();
+    });
+
+    it('removes expired nvq_hid from localStorage before writing a new value', function () {
+      const cookiesEnabled = sinon.stub(novatiqStorage, 'cookiesAreEnabled').returns(false);
+      const hasLocalStorage = sinon.stub(novatiqStorage, 'hasLocalStorage').returns(true);
+      const getLs = sinon.stub(novatiqStorage, 'getDataFromLocalStorage').returns(JSON.stringify({
+        hyperId: 'stale-id',
+        expiresAt: Date.now() - 1000
+      }));
+      const removeLs = sinon.stub(novatiqStorage, 'removeDataFromLocalStorage');
+      const setLs = sinon.stub(novatiqStorage, 'setDataInLocalStorage');
+      const scheduleExpiry = sinon.stub(novatiqIdSubmodule, 'scheduleEphemeralHyperIdLocalStorageExpiry');
+      novatiqIdSubmodule.persistEphemeralHyperId('hid-local');
+      expect(removeLs.calledWith('nvq_hid')).to.equal(true);
+      expect(setLs.calledOnce).to.equal(true);
+      scheduleExpiry.restore();
+      cookiesEnabled.restore();
+      hasLocalStorage.restore();
+      getLs.restore();
+      removeLs.restore();
+      setLs.restore();
+    });
+
+    it('schedules localStorage removal after TTL', function () {
+      const clock = sinon.useFakeTimers();
+      const cookiesEnabled = sinon.stub(novatiqStorage, 'cookiesAreEnabled').returns(false);
+      const hasLocalStorage = sinon.stub(novatiqStorage, 'hasLocalStorage').returns(true);
+      const getLs = sinon.stub(novatiqStorage, 'getDataFromLocalStorage').returns(null);
+      const setLs = sinon.stub(novatiqStorage, 'setDataInLocalStorage');
+      const removeLs = sinon.stub(novatiqStorage, 'removeDataFromLocalStorage');
+      novatiqIdSubmodule.persistEphemeralHyperId('hid-local');
+      expect(removeLs.called).to.equal(false);
+      clock.tick(60000);
+      expect(removeLs.calledWith('nvq_hid')).to.equal(true);
+      clock.restore();
+      cookiesEnabled.restore();
+      hasLocalStorage.restore();
+      getLs.restore();
+      setLs.restore();
+      removeLs.restore();
     });
   });
 


### PR DESCRIPTION
Localstorage expiry
With useCallbacks: true, persistEphemeralHyperId ran before the sync XHR finished. The User ID module only treats the ID as valid on 200 or 204; on other successful statuses (or failure) there is no accepted ID, but nvq_hid was already written—so downstream readers (e.g. Amazon) could see a Hyper ID that Prebid never adopted.